### PR TITLE
Removed if condition for setting self.publisher from CounterEresource

### DIFF
--- a/pycounter/report.py
+++ b/pycounter/report.py
@@ -227,8 +227,7 @@ class CounterEresource(six.Iterator):
             self.title = title
         if platform:
             self.platform = platform
-        if publisher:
-            self.publisher = publisher
+        self.publisher = publisher
 
     def __iter__(self):
         if self._full_data:


### PR DESCRIPTION
ItemPublisher is listed in schema with minOccurs="0"
Not required for every field for valid Counter report
When if condition fails and self.publisher is not set various methods
such as CounterReport.write_tsv throw AttributeError exceptions because
they assume self.publisher.
Causes failure of writing and reading reports from some Counter compliant
vendors.