### PR TITLE
DB Sushi Code Quality

### DIFF
--- a/pycounter/constants.py
+++ b/pycounter/constants.py
@@ -11,7 +11,22 @@ METRICS = {
     u"JR1": u"FT Article Requests",
     u"JR1 GOA": u"Gold Open Access Article Requests",
     u"BR1": u"Book Title Requests",
-    u"BR2": u"Book Section Requests"
+    u"BR2": u"Book Section Requests",
+    u"DB1": [u"Regular Searches",
+             u"Searches-federated and automated",
+             u"Result Clicks",
+             u"Record Views"],
+    u"DB2": [u"Access denied: concurrent/simultaneous user license exceeded",
+             u"Access denied: content item not licensed"]
+}
+
+DB_METRIC_MAP = {
+    "search_reg": METRICS["DB1"][0],
+    "search_fed": METRICS["DB1"][1],
+    "result_click": METRICS["DB1"][2],
+    "record_view": METRICS["DB1"][3],
+    "turnaway": METRICS["DB2"][0],
+    "no_license": METRICS["DB2"][1]
 }
 
 CODES = {

--- a/pycounter/report.py
+++ b/pycounter/report.py
@@ -210,10 +210,6 @@ class CounterReport(object):
         metric is missing add a 0 use :class:`CounterDatabase<CounterDatabase>`
         Assumes platform and publisher are consistent across records
         """
-        db_report_metrics = {'DB1': ['search_reg', 'search_fed',
-                                     'result_click', 'record_view'],
-                             'DB2': ['turnaway', 'no_license']}
-
         try:
             required_metrics = db_report_metrics[self.report_type]
         except LookupError:
@@ -456,15 +452,6 @@ class CounterDatabase(CounterEresource):
     # pylint: disable=too-few-public-methods
     """a COUNTER database report line"""
 
-    metric_full_titles = {'search_reg': 'Regular Searches',
-                          'search_fed': 'Searches-federated and automated',
-                          'result_click': 'Result Clicks',
-                          'record_view': 'Record Views',
-                          'turnaway': 'Access denied: concurrent/'
-                                      'simultaneous user license exceeded',
-                          'no_license': 'Access denied: content item not '
-                                        'licensed'}
-
     def __init__(self, period=None, metric=None, month_data=None,
                  title="", platform="", publisher=""):
         super(CounterDatabase, self).__init__(period, metric, month_data,
@@ -475,16 +462,13 @@ class CounterDatabase(CounterEresource):
         """
         return data for this line as list of COUNTER report cells
         """
-
         self._fill_months()
-        # map SUSHI code to full title if SUSHI, leave metric alone otherwise
-        metric = CounterDatabase.metric_full_titles.get(self.metric,
-                                                        self.metric)
+
         data_line = [
             self.title,
             self.publisher,
             self.platform,
-            metric,
+            self.metric,
         ]
         total_usage = 0
         month_data = []

--- a/pycounter/sushi.py
+++ b/pycounter/sushi.py
@@ -260,7 +260,9 @@ def _raw_to_full(raw_report):
                         month_data=month_data,
                     ))
             elif report.report_type.startswith('DB'):
-                for metric, month_data in six.iteritems(metrics_for_db):
+                metric_map = pycounter.constants.METRIC['DB_METRIC_MAP']
+                for metric_code, month_data in six.iteritems(metrics_for_db):
+                    metric = metric_map[metric_code]
                     report.pubs.append(
                         pycounter.report.CounterDatabase(
                             title=title,

--- a/pycounter/sushi.py
+++ b/pycounter/sushi.py
@@ -260,9 +260,8 @@ def _raw_to_full(raw_report):
                         month_data=month_data,
                     ))
             elif report.report_type.startswith('DB'):
-                metric_map = pycounter.constants.METRIC['DB_METRIC_MAP']
                 for metric_code, month_data in six.iteritems(metrics_for_db):
-                    metric = metric_map[metric_code]
+                    metric = pycounter.constants.DB_METRIC_MAP[metric_code]
                     report.pubs.append(
                         pycounter.report.CounterDatabase(
                             title=title,

--- a/pycounter/test/test_db1.py
+++ b/pycounter/test/test_db1.py
@@ -37,7 +37,7 @@ class ParseCounter4Example(unittest.TestCase):
 
     def test_report_metric(self):
         for metric in self.report.metric:
-            self.assertIn(metric, METRICS[self.report.report_type])
+            self.assertTrue(metric in METRICS[self.report.report_type])
 
     def test_row_metric(self):
         publication = self.report.pubs[0]

--- a/pycounter/test/test_db1.py
+++ b/pycounter/test/test_db1.py
@@ -6,6 +6,7 @@ import datetime
 import os
 import unittest
 
+from pycounter.constants import METRICS
 import pycounter.report
 
 
@@ -35,7 +36,8 @@ class ParseCounter4Example(unittest.TestCase):
             [0, 20, 0, 0, 5, 0])
 
     def test_report_metric(self):
-        self.assertEqual(self.report.metric, None)
+        for metric in self.report.metric:
+            self.assertIn(metric, METRICS[self.report.report_type])
 
     def test_row_metric(self):
         publication = self.report.pubs[0]

--- a/pycounter/test/test_db2.py
+++ b/pycounter/test/test_db2.py
@@ -37,7 +37,7 @@ class ParseCounter4Example(unittest.TestCase):
 
     def test_report_metric(self):
         for metric in self.report.metric:
-            self.assertIn(metric, METRICS[self.report.report_type])
+            self.assertTrue(metric in METRICS[self.report.report_type])
 
     def test_row_metric(self):
         publication = self.report.pubs[0]

--- a/pycounter/test/test_db2.py
+++ b/pycounter/test/test_db2.py
@@ -6,6 +6,7 @@ import datetime
 import os
 import unittest
 
+from pycounter.constants import METRICS
 import pycounter.report
 
 
@@ -35,7 +36,8 @@ class ParseCounter4Example(unittest.TestCase):
             [0, 5, 0, 0, 0, 0])
 
     def test_report_metric(self):
-        self.assertEqual(self.report.metric, None)
+        for metric in self.report.metric:
+            self.assertIn(metric, METRICS[self.report.report_type])
 
     def test_row_metric(self):
         publication = self.report.pubs[0]

--- a/pycounter/test/test_sushi.py
+++ b/pycounter/test/test_sushi.py
@@ -139,25 +139,25 @@ class TestConvertRawDatabase(unittest.TestCase):
     def test_search_reg(self):
         database = self.databases[0]
         data = [month[2] for month in database]
-        self.assertEqual(database.metric, u'search_reg')
+        self.assertEqual(database.metric, u'Regular Searches')
         self.assertEqual(data[0], 5)
 
     def test_search_fed(self):
         database = self.databases[1]
         data = [month[2] for month in database]
-        self.assertEqual(database.metric, u'search_fed')
+        self.assertEqual(database.metric, u'Searches-federated and automated')
         self.assertEqual(data[0], 13)
 
     def test_result_click(self):
         database = self.databases[2]
         data = [month[2] for month in database]
-        self.assertEqual(database.metric, u'result_click')
+        self.assertEqual(database.metric, u'Result Clicks')
         self.assertEqual(data[0], 16)
 
     def test_record_view(self):
         database = self.databases[3]
         data = [month[2] for month in database]
-        self.assertEqual(database.metric, u'record_view')
+        self.assertEqual(database.metric, u'Record Views')
         self.assertEqual(data[0], 7)
 
 
@@ -179,13 +179,13 @@ class TestRawDatabaseWithMissingData(unittest.TestCase):
     def test_january(self):
         database = self.databases[1]
         data = [month[2] for month in database]
-        self.assertEqual(database.metric, u'search_fed')
+        self.assertEqual(database.metric, u'Searches-federated and automated')
         self.assertEqual(data[0], 0)
 
     def test_record_view(self):
         database = self.databases[3]
         data = [month[2] for month in database]
-        self.assertEqual(database.metric, u'record_view')
+        self.assertEqual(database.metric, u'Record Views')
         self.assertEqual(data[0], 0)
 
 


### PR DESCRIPTION
Functionality is largely the same as previous pull, just made some code quality improvements to help maintainability.

Moved hard-coded dicts from report.py to constants.py to keep hard-coded information corralled. This also simplified some checking code within CounterReport._ensure_all_metrics and CounterDatabase.as_generic.

Moving the mapping of SUSHI codes to COUNTER names into the sushi.py also makes for more internal consistency, all Counter objects now have the full name from the beginning.

Updated the tests to expect full field names from SUSHI requests and not expect None for metric when parsing DB1 and DB2