### PR TITLE
Allow csvwriter to accept fileobjs

### DIFF
--- a/pycounter/csvhelper.py
+++ b/pycounter/csvhelper.py
@@ -76,6 +76,7 @@ class UnicodeWriter(object):
         self.lineterminator = lineterminator
         self.kwargs = kwargs
         self.writer = None
+        self.fileobj = None
         if type(self.filename) is not str:
             self.fileobj = filename
 

--- a/pycounter/csvhelper.py
+++ b/pycounter/csvhelper.py
@@ -76,21 +76,24 @@ class UnicodeWriter(object):
         self.lineterminator = lineterminator
         self.kwargs = kwargs
         self.writer = None
-        self.fileobj = None
+        if type(self.filename) is not str:
+            self.fileobj = filename
 
     def __enter__(self):
-        if six.PY3:
-            self.fileobj = open(self.filename, 'wt',
-                                encoding=self.encoding, newline='')
-        else:
-            self.fileobj = open(self.filename, 'wb')
+        if self.fileobj is None:
+            if six.PY3:
+                self.fileobj = open(self.filename, 'wt',
+                                    encoding=self.encoding, newline='')
+            else:
+                self.fileobj = open(self.filename, 'wb')
         self.writer = csv.writer(self.fileobj, dialect=self.dialect,
                                  lineterminator=self.lineterminator,
                                  **self.kwargs)
         return self
 
     def __exit__(self, type_, value, traceback):
-        self.fileobj.close()
+        if type(self.filename) is str:
+            self.fileobj.close()
 
     def writerow(self, row):
         """write a row to the output


### PR DESCRIPTION
In some circumstances it's nice to be able to provide a file descriptor to the CSVWriter function to provide more flexibility regarding how the data is written.

This is particularly useful when working with http://pyfilesystem.org/ for filesystem abstraction.