### PR TITLE
Fix incorrect first_date_col for DB1 reports

### DIFF
--- a/pycounter/report.py
+++ b/pycounter/report.py
@@ -763,9 +763,7 @@ def _year_from_header(header, report):
     first_date_col = 10 if report.report_version == 4 else 5
     if report.report_type in ('BR1', 'BR2') and report.report_version == 4:
         first_date_col = 8
-    elif report.report_type == 'DB1' and report.report_version == 4:
-        first_date_col = 6
-    elif report.report_type == 'DB2' and report.report_version == 4:
+    elif report.report_type in ('DB1','DB2') and report.report_version == 4:
         first_date_col = 5
     year = int(header[first_date_col].split('-')[1])
     if year < 100:


### PR DESCRIPTION
The first date column in a DB1 report should actually have index 5 (6th column).  See: https://www.projectcounter.org/code-of-practice-sections/usage-reports/#databases