### PR TITLE
Retry SUSHI reports if "Report Queued" message is returned.

### DIFF
--- a/pycounter/sushiclient.py
+++ b/pycounter/sushiclient.py
@@ -42,7 +42,8 @@ logging.basicConfig()
               help='Output file to write (will be overwritten)',
               type=click.Path(writable=True))
 @click.option('--dump', '-d', is_flag=True)
-@click.option('--no-delay', is_flag=True, )
+@click.option('--no-delay', is_flag=True,
+              help="Do not delay before rerequesting a queued report. Probably don't do this to a real server.")
 def main(url, report, release, start_date, end_date, requestor_id,
          requestor_email, requestor_name, customer_name,
          customer_reference, format_, output_file, dump, no_delay):

--- a/pycounter/sushiclient.py
+++ b/pycounter/sushiclient.py
@@ -42,9 +42,10 @@ logging.basicConfig()
               help='Output file to write (will be overwritten)',
               type=click.Path(writable=True))
 @click.option('--dump', '-d', is_flag=True)
+@click.option('--no-delay', is_flag=True, )
 def main(url, report, release, start_date, end_date, requestor_id,
          requestor_email, requestor_name, customer_name,
-         customer_reference, format_, output_file, dump):
+         customer_reference, format_, output_file, dump, no_delay):
     """Main function for the SUSHI client."""
     click.echo("pycounter SUSHI client for URL %s (%s R%s)"
                % (url, report, release))
@@ -70,7 +71,8 @@ def main(url, report, release, start_date, end_date, requestor_id,
                               customer_name=customer_name,
                               start_date=converted_start_date,
                               end_date=converted_end_date,
-                              sushi_dump=dump)
+                              sushi_dump=dump,
+                              no_delay=no_delay)
     output_file = output_file % format_
     report.write_to_file(output_file, format_)
 

--- a/pycounter/sushiclient.py
+++ b/pycounter/sushiclient.py
@@ -43,7 +43,8 @@ logging.basicConfig()
               type=click.Path(writable=True))
 @click.option('--dump', '-d', is_flag=True)
 @click.option('--no-delay', is_flag=True,
-              help="Do not delay before rerequesting a queued report. Probably don't do this to a real server.")
+              help="Do not delay before rerequesting a queued report. "
+                   "Probably don't do this to a real server.")
 def main(url, report, release, start_date, end_date, requestor_id,
          requestor_email, requestor_name, customer_name,
          customer_reference, format_, output_file, dump, no_delay):

--- a/pycounter/test/data/sushi_queued.xml
+++ b/pycounter/test/data/sushi_queued.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" ?>
+<!--suppress CheckTagEmptyBody -->
+<S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/">
+    <S:Body>
+        <ns3:ReportResponse xmlns="http://www.niso.org/schemas/counter"
+                            xmlns:ns2="http://www.niso.org/schemas/sushi"
+                            xmlns:ns3="http://www.niso.org/schemas/sushi/counter"
+                            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <ns2:Exception>
+                <ns2:Number>4001</ns2:Number>
+                <ns2:Severity>Info</ns2:Severity>
+                <ns2:Message>Report Queued</ns2:Message>
+            </ns2:Exception>
+            <!--suppress CheckTagEmptyBody -->
+            <ns2:Requestor>
+                <ns2:ID>exampleRequestor</ns2:ID>
+                <ns2:Name></ns2:Name>
+                <ns2:Email></ns2:Email>
+            </ns2:Requestor>
+            <ns2:CustomerReference>
+                <ns2:ID>exampleReference</ns2:ID>
+                <ns2:Name></ns2:Name>
+            </ns2:CustomerReference>
+            <ns2:ReportDefinition Release="4" Name="JR1">
+                <ns2:Filters>
+                    <ns2:UsageDateRange>
+                        <ns2:Begin>2013-01-01</ns2:Begin>
+                        <ns2:End>2013-01-31</ns2:End>
+                    </ns2:UsageDateRange>
+                </ns2:Filters>
+            </ns2:ReportDefinition>
+            <ns3:Report xsi:nil="true"/>
+         </ns3:ReportResponse>
+    </S:Body>
+</S:Envelope>

--- a/pycounter/test/test_sushi.py
+++ b/pycounter/test/test_sushi.py
@@ -18,10 +18,12 @@ import pycounter.exceptions
 @urlmatch(netloc=r'(.*\.)?example\.com$')
 def report_queued_mock(url_unused, request_unused):
     if report_queued_mock.first_request:
-        path = os.path.join(os.path.dirname(__file__), 'data', 'sushi_queued.xml')
+        path = os.path.join(os.path.dirname(__file__), 'data',
+                            'sushi_queued.xml')
         report_queued_mock.first_request = False
     else:
-        path = os.path.join(os.path.dirname(__file__), 'data', 'sushi_simple.xml')
+        path = os.path.join(os.path.dirname(__file__), 'data',
+                            'sushi_simple.xml')
     with open(path, 'rb') as datafile:
         return datafile.read().decode('utf-8')
 
@@ -353,4 +355,3 @@ class TestMissingItemIdentifier(unittest.TestCase):
     def test_issn(self):
         publication = next(iter(self.report))
         self.assertEqual(publication.issn, "")
-

--- a/pycounter/test/test_sushi.py
+++ b/pycounter/test/test_sushi.py
@@ -16,6 +16,20 @@ import pycounter.exceptions
 
 
 @urlmatch(netloc=r'(.*\.)?example\.com$')
+def report_queued_mock(url_unused, request_unused):
+    if report_queued_mock.first_request:
+        path = os.path.join(os.path.dirname(__file__), 'data', 'sushi_queued.xml')
+        report_queued_mock.first_request = False
+    else:
+        path = os.path.join(os.path.dirname(__file__), 'data', 'sushi_simple.xml')
+    with open(path, 'rb') as datafile:
+        return datafile.read().decode('utf-8')
+
+
+report_queued_mock.first_request = True
+
+
+@urlmatch(netloc=r'(.*\.)?example\.com$')
 def sushi_mock(url_unused, request_unused):
     path = os.path.join(os.path.dirname(__file__),
                         'data', 'sushi_simple.xml')
@@ -312,6 +326,20 @@ class TestSushiClient(unittest.TestCase):
                 result = runner.invoke(sushiclient.main, arglist)
                 self.assertEqual(result.exit_code, 0)
 
+    def test_queued_report(self):
+        """Test that queued report is retried"""
+        arglist = [
+            'http://www.example.com/Sushi',
+            '-s', '2013-01-01',
+            '-e', '2013-01-31',
+            '--no-delay',
+        ]
+        with HTTMock(report_queued_mock):
+            runner = CliRunner()
+            with runner.isolated_filesystem():
+                result = runner.invoke(sushiclient.main, arglist)
+                self.assertEqual(result.exit_code, 0)
+
 
 class TestMissingItemIdentifier(unittest.TestCase):
     """Test converting simple SUSHI response"""
@@ -325,3 +353,4 @@ class TestMissingItemIdentifier(unittest.TestCase):
     def test_issn(self):
         publication = next(iter(self.report))
         self.assertEqual(publication.issn, "")
+


### PR DESCRIPTION
(This is kind of an ugly hack that looks for this string in the
raw XML. A nicer fix will be possible with a fix for #3 )

Fixes #65 