### PR TITLE
make it possible to pass extra parameters to the requests.post call

### DIFF
--- a/pycounter/sushi.py
+++ b/pycounter/sushi.py
@@ -38,7 +38,7 @@ def get_sushi_stats_raw(
     release=4,
     sushi_dump=False,
     verify=True,
-    **extra_params,
+    **extra_params
 ):
     """Get SUSHI stats for a given site in raw XML format.
 
@@ -118,8 +118,9 @@ def get_sushi_stats_raw(
         "Content-Length": str(len(payload)),
     }
 
-    response = requests.post(url=wsdl_url, headers=headers, data=payload, verify=verify,
-                             **extra_params)
+    response = requests.post(
+        url=wsdl_url, headers=headers, data=payload, verify=verify, **extra_params
+    )
 
     if sushi_dump:
         logger.debug(

--- a/pycounter/sushi.py
+++ b/pycounter/sushi.py
@@ -38,7 +38,7 @@ def get_sushi_stats_raw(
     release=4,
     sushi_dump=False,
     verify=True,
-    extra_params=None,
+    **extra_params,
 ):
     """Get SUSHI stats for a given site in raw XML format.
 
@@ -67,7 +67,7 @@ def get_sushi_stats_raw(
 
     :param verify: bool: whether to verify SSL certificates
 
-    :param extra_params: dict with extra params passed to requests.post
+    :param extra_params: extra params are passed to requests.post
 
     """
     # pylint: disable=too-many-locals
@@ -118,8 +118,6 @@ def get_sushi_stats_raw(
         "Content-Length": str(len(payload)),
     }
 
-    if extra_params is None:
-        extra_params = {}
     response = requests.post(url=wsdl_url, headers=headers, data=payload, verify=verify,
                              **extra_params)
 

--- a/pycounter/sushi.py
+++ b/pycounter/sushi.py
@@ -38,6 +38,7 @@ def get_sushi_stats_raw(
     release=4,
     sushi_dump=False,
     verify=True,
+    extra_params=None,
 ):
     """Get SUSHI stats for a given site in raw XML format.
 
@@ -65,6 +66,8 @@ def get_sushi_stats_raw(
     :param sushi_dump: produces dump of XML (or JSON, for COUNTER 5) to DEBUG logger
 
     :param verify: bool: whether to verify SSL certificates
+
+    :param extra_params: dict with extra params passed to requests.post
 
     """
     # pylint: disable=too-many-locals
@@ -115,7 +118,10 @@ def get_sushi_stats_raw(
         "Content-Length": str(len(payload)),
     }
 
-    response = requests.post(url=wsdl_url, headers=headers, data=payload, verify=verify)
+    if extra_params is None:
+        extra_params = {}
+    response = requests.post(url=wsdl_url, headers=headers, data=payload, verify=verify,
+                             **extra_params)
 
     if sushi_dump:
         logger.debug(


### PR DESCRIPTION
Hello,

I found that some SUSHI providers (AMS in my case) require HTTP basic authentication when accessing their SUSHI service. This update makes is possible to simply pass any extra keyword arguments from `get_sushi_stats_raw` to the `requests.post` call, which can then be used to pass the `auth` argument required for HTTP basic authentication.
Best regards
Beda