### PR TITLE
fix error in totals computation with sparse data

### DIFF
--- a/pycounter/report.py
+++ b/pycounter/report.py
@@ -198,19 +198,17 @@ class CounterReport(object):
         pdf_usage = 0
         html_usage = 0
 
-        number_of_months = len(
-            list(pendulum.period(self.period[0], self.period[1]).range("months"))
-        )
-        month_data = [0] * number_of_months
+        months = list(pendulum.period(self.period[0], self.period[1]).range("months"))
+        month_data = [0] * len(months)
         for pub in self.pubs:
             if pub.metric != metric:
                 continue
             if self.report_type == "JR1":
                 pdf_usage += pub.pdf_total  # pytype: disable=attribute-error
                 html_usage += pub.html_total  # pytype: disable=attribute-error
-            for month, data in enumerate(pub):
+            for data in pub:
                 total_usage += data[2]
-                month_data[month] += data[2]
+                month_data[months.index(data[0])] += data[2]
         total_cells.append(six.text_type(total_usage))
         if self.report_type == "JR1":
             total_cells.append(six.text_type(html_usage))
@@ -311,6 +309,7 @@ class CounterEresource(six.Iterator):
     def _fill_months(self):
         """Ensure each month in period represented and zero fill if not."""
         start, end = self.period[0], self.period[1]
+        # TODO: ensure start, end are first days of month
         try:
             for d_obj in pendulum.period(start, end).range("months"):
                 if d_obj not in (x[0] for x in self._full_data):

--- a/pycounter/test/test_output_common.py
+++ b/pycounter/test/test_output_common.py
@@ -1,4 +1,7 @@
 """Check data in common output formats."""
+from datetime import date
+
+from pycounter.report import CounterBook, CounterReport
 
 
 def test_header_content(common_output):
@@ -26,3 +29,33 @@ def test_writing_file(report_file_output, tmp_path):
         new_content = new_file.read()
 
     assert expected_data == new_content
+
+
+def test_totals_sparse_data(tmp_path):
+    """
+    Check that when sparse data (data where some months are missing) are used, both
+    the monthly totals and the monthly data are properly outputed into TSV
+    """
+
+    start = date(2019, 1, 1)
+    end = date(2019, 3, 31)
+    cb1 = CounterBook(period=(start, end), title="Book 1",
+                      month_data=[(date(2019, 2, 1), 3), (date(2019, 3, 1), 5)])
+    cb2 = CounterBook(period=(start, end), title="Book 2",
+                      month_data=[(date(2019, 1, 1), 1), (date(2019, 3, 1), 7)])
+    report = CounterReport(report_type="BR2", period=(start, end))
+    report.pubs = [cb1, cb2]
+    report.write_tsv(str(tmp_path / "outputfile.tsv"))
+    with open(str(tmp_path / "outputfile.tsv"), "r") as new_file:
+        output_lines = list(new_file.readlines())
+    assert len(output_lines) == 11
+    # check totals computation
+    totals_line = output_lines[8]
+    assert totals_line.startswith("Total for all titles")
+    totals = totals_line.split("\t")
+    assert [int(t) for t in totals[-3:]] == [0+1, 3+0, 5+7], "check totals match"
+    # book 1 line
+    book_line = output_lines[9]
+    assert book_line.startswith("Book 1")
+    numbers = [int(num) for num in book_line.split("\t")[-3:]]
+    assert numbers == [0, 3, 5], "check counts for book 1"


### PR DESCRIPTION
Hello,

I found that when there are sparse data for some titles (i.e. only data for a few months are present in the input data), the totals for each month are not computed correctly. The first present value would be summed into the first month total even if the value was actually for a much later month.
I created a simple fix and also added a test for this case.

Cheers
Beda